### PR TITLE
feat: upgrade Card component to Bootstrap 5

### DIFF
--- a/src/scss/_card.scss
+++ b/src/scss/_card.scss
@@ -1,4 +1,21 @@
-@import "bootstrap/scss/_card.scss";
+// Bootstrap variables
+$card-spacer-y:       1rem !default;
+$card-spacer-x:       1.25rem !default;
+$card-title-spacer-y: $spacer * .5 !default;
+$card-border-width:   0 !default;
+$card-cap-bg:         $white !default;
+$card-cap-padding-y:  $card-spacer-y * .5 !default;
+$card-cap-padding-x:  $card-spacer-x !default;
+$card-box-shadow:     null !default;
+$card-height:         null !default;
+
+$card-block-padding:  1rem 1.25rem 1.5rem !default;
+$card-footer-padding: 1.25rem 1.25rem 1.5rem !default;
+
+// DEPRICATED IN Bootstrap v5
+// $card-deck-margin:    .625rem !default;
+
+@import "bootstrap5/scss/_card.scss";
 
 .card-block {
   padding: $card-block-padding;

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -563,14 +563,6 @@ $pattern-diagonal-stripes-gray-bg: #ececec;
 $pattern-diagonal-stripes-gray-border: $shadow;
 $pattern-diagonal-stripes-gray-font-color: $black;
 
-$card-spacer-y: 1rem;
-$card-spacer-x: 1.25rem;
-$card-border-width: 0;
-$card-cap-bg: $white;
-$card-block-padding: 1rem 1.25rem 1.5rem;
-$card-footer-padding: 1.25rem 1.25rem 1.5rem;
-$card-deck-margin: .625rem;
-
 $tooltip-padding-y: 3px;
 $tooltip-padding-x: 8px;
 $tooltip-margin: 3px;


### PR DESCRIPTION
BREAKING CHANGE: Card-deck is removed from Bootstrap 5