### PR TITLE
Add components build

### DIFF
--- a/components.vite.config.js
+++ b/components.vite.config.js
@@ -1,0 +1,20 @@
+import { mergeConfig } from 'vite'
+import { resolve } from 'path'
+
+export default mergeConfig({
+  build: {
+    lib: {
+      entry: [
+        resolve(__dirname, 'src/js/components/monthpicker.jsx'),
+        resolve(__dirname, 'src/js/components/datepicker.js'),
+        resolve(__dirname, 'src/js/components/interval.js'),
+        resolve(__dirname, 'src/js/components/select.js')
+      ],
+      formats: ['es'],
+      fileName(format, name) {
+        return `${name}.${format}.js`
+      }
+    },
+    outDir: 'dist/components'
+  }
+})

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   },
   "scripts": {
     "start": "storybook dev -p 6006 --no-open",
-    "build": "npm run build:lfui && npm run build:types && npm run build:docs && storybook build -o static",
+    "build": "npm run build:lfui && npm run build:components && npm run build:types && npm run build:docs && storybook build -o static",
     "build:lfui": "vite build",
     "build:docs": "vite build -c docs.vite.config.js",
+    "build:components": "vite build -c components.vite.config.js",
     "build:types": "tsc -p ./jsconfig.json --declaration --noEmit false --emitDeclarationOnly --outFile dist/lfui/index.d.ts",
     "deploy": "npm run build && gh-pages -d static",
     "test": "npm run lint:scss && npm run lint:js",


### PR DESCRIPTION
Det är inte vackert och som jag sa i mötet så bör en använda någon typ av bygge för att importera specifika komponenter då denna lösning innebär att delade beroenden hamnar i en extern fil (`utils-HASH.js`) och importeras dynamiskt. Alltså blir det väldigt känsligt för hur filerna ligger på servern.

Den inkluderar heller inte CSS men det kanske kan lösas genom att vi också vill exponera individuella CSS-filer för import.

Men om det löser deras problem så antar jag att det är en win?