### PR TITLE
fix: add not-allowed cursor on disabled days in datepicker

### DIFF
--- a/src/scss/_datepicker.scss
+++ b/src/scss/_datepicker.scss
@@ -302,6 +302,7 @@
 
     &.is-disabled {
       box-shadow: none;
+      cursor: not-allowed;
     }
 
     &:hover::before,

--- a/src/scss/_datepicker.scss
+++ b/src/scss/_datepicker.scss
@@ -301,8 +301,8 @@
     }
 
     &.is-disabled {
-      box-shadow: none;
       cursor: not-allowed;
+      box-shadow: none;
     }
 
     &:hover::before,


### PR DESCRIPTION
The not-allowed cursor on disabled days got lost somewhere, but now it's back!